### PR TITLE
Import misc and kdtree

### DIFF
--- a/uniflowmatch/utils/geometry.py
+++ b/uniflowmatch/utils/geometry.py
@@ -10,6 +10,9 @@ import einops as ein
 import numpy as np
 import torch
 
+from uniflowmatch.utils.misc import invalid_to_nans
+from scipy.spatial import KDTree
+
 
 def depthmap_to_camera_frame(depthmap, intrinsics):
     """


### PR DESCRIPTION
- Import ```invalid_to_nans``` and ```KDTree``` in the ```geometry.py```
- They are not currently being used, but better to fix for a future use. 