### PR TITLE
Make `uniflowmatch` installable without edit mode (-e)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Package installation setup."""
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # Read long description from README
 try:
@@ -58,7 +58,7 @@ setup(
     author_email="yuchenz7@andrew.cmu.edu",
     url="https://uniflowmatch.github.io/",
     license="BSD Clause-3",
-    packages=["uniception", "uniflowmatch"],  # Directly specify the package
+    packages=find_packages(include=["uniception", "uniflowmatch*"]),
     package_dir={
         "uniception": "UniCeption/uniception",  # Map uniception package
         "uniflowmatch": "uniflowmatch",  # Map uniflowmatch package

--- a/uniflowmatch/models/base.py
+++ b/uniflowmatch/models/base.py
@@ -74,7 +74,7 @@ class UFMOutputInterface:
 
 from uniception.models.encoders.image_normalizations import IMAGE_NORMALIZATION_DICT
 
-from uniflowmatch.utils.flow_resizing import (
+from ..utils.flow_resizing import (
     AutomaticShapeSelection,
     ResizeToFixedManipulation,
     unmap_predicted_channels,

--- a/uniflowmatch/models/ufm.py
+++ b/uniflowmatch/models/ufm.py
@@ -24,15 +24,15 @@ from uniception.models.prediction_heads.dpt import DPTFeature, DPTRegressionProc
 from uniception.models.prediction_heads.mlp_feature import MLPFeature
 from uniception.models.prediction_heads.moge_conv import MoGeConvFeature
 
-from uniflowmatch.models.base import (
+from .base import (
     UFMClassificationRefinementOutput,
     UFMFlowFieldOutput,
     UFMMaskFieldOutput,
     UFMOutputInterface,
     UniFlowMatchModelsBase,
 )
-from uniflowmatch.models.unet_encoder import UNet
-from uniflowmatch.models.utils import get_meshgrid_torch
+from .unet_encoder import UNet
+from .utils import get_meshgrid_torch
 
 CLASSNAME_TO_ADAPTOR_CLASS = {
     "FlowWithConfidenceAdaptor": FlowWithConfidenceAdaptor,


### PR DESCRIPTION
Hi, 

Thanks for your great work on this project. We (cc @gmberton) are working to integrate it into [IMM](https://github.com/gmberton/image-matching-models), but are running into some challenges due to UFM only working when installed in editable mode (with `-e`)

This small changes allows UFM to be installed with just
`pip install .`

Let me know if you have any questions or requested changes. 